### PR TITLE
Añadir funcionalidad de filtrar por fecha

### DIFF
--- a/AndroidProject/app/src/main/java/com/isunican/eventossantander/presenter/events/EventsPresenter.java
+++ b/AndroidProject/app/src/main/java/com/isunican/eventossantander/presenter/events/EventsPresenter.java
@@ -27,8 +27,7 @@ public class EventsPresenter implements IEventsContract.Presenter {
     private List<Event> eventosEnDeterminadosFiltros;
     private List<Event> eventosEnFiltrosCombinados;
     private int ordenFiltrado;
-
-
+    
     public List<Event> getEventosEnDeterminadasFechas() {
         return eventosEnDeterminadasFechas;
     }


### PR DESCRIPTION
Esta rama añade la funcionalidad de filtrar por fecha a la aplicación. El usuario podrá seleccionar el icono de filtrar por fecha en la parte superior de la pantalla y hacer que los eventos que se le muestren estén comprendidos entre las fechas de inicio y fin que seleccione.